### PR TITLE
Add tag support for S3 buckets

### DIFF
--- a/lib/terraforming/resource/s3.rb
+++ b/lib/terraforming/resource/s3.rb
@@ -22,17 +22,22 @@ module Terraforming
       def tfstate
         buckets.inject({}) do |resources, bucket|
           bucket_policy = bucket_policy_of(bucket)
+
+          attributes = {
+            "acl" => "private",
+            "bucket" => bucket.name,
+            "force_destroy" => "false",
+            "id" => bucket.name,
+            "policy" => bucket_policy ? bucket_policy.policy.read : ""
+          }
+
+          attributes.merge!(tags_attributes_of(bucket))
+
           resources["aws_s3_bucket.#{module_name_of(bucket)}"] = {
             "type" => "aws_s3_bucket",
             "primary" => {
               "id" => bucket.name,
-              "attributes" => {
-                "acl" => "private",
-                "bucket" => bucket.name,
-                "force_destroy" => "false",
-                "id" => bucket.name,
-                "policy" => bucket_policy ? bucket_policy.policy.read : "",
-              }
+              "attributes" => attributes
             }
           }
 
@@ -41,6 +46,22 @@ module Terraforming
       end
 
       private
+
+      def tags_attributes_of(bucket)
+        tags = tags_of(bucket)
+        if tags == nil
+          return {}
+        end
+
+        attributes = { "tags.%" => tags.length.to_s }
+
+        
+        tags.each do |tag|
+          attributes["tags.#{tag.key}"] = tag.value
+        end
+
+        attributes
+      end
 
       def bucket_location_of(bucket)
         @client.get_bucket_location(bucket: bucket.name).location_constraint
@@ -63,6 +84,14 @@ module Terraforming
       def same_region?(bucket)
         bucket_location = bucket_location_of(bucket)
         (bucket_location == @client.config.region) || (bucket_location == "" && @client.config.region == "us-east-1")
+      end
+
+      def tags_of(bucket)
+        begin
+          return @client.get_bucket_tagging({bucket: bucket.name}).tag_set
+        rescue Aws::S3::Errors::NoSuchTagSet
+          return nil
+        end
       end
     end
   end

--- a/lib/terraforming/template/tf/s3.erb
+++ b/lib/terraforming/template/tf/s3.erb
@@ -7,6 +7,14 @@ resource "aws_s3_bucket" "<%= module_name_of(bucket) %>" {
 <%= prettify_policy(policy.policy.read) %>
 POLICY
 <%- end -%>
+
+<% unless (tags = tags_of(bucket)).nil? -%>
+	tags {
+	<%- tags.each do |tag| -%>
+		<%= tag.key %> = "<%= tag.value %>"
+	<%- end -%>
+	}
+<% end -%>
 }
 
 <% end -%>


### PR DESCRIPTION
The first of several PRs to expand the terraforming capabilities for S3 buckets.

This adds support for importing tags stored on S3 buckets to .tf and .tfstate files. Tested against Button production resources.